### PR TITLE
Upgraded to Steeltoe version 2.4.0 to support SCS 3.0 in addition to …

### DIFF
--- a/src/Web.Config.Transform.Buildpack/Web.Config.Transform.Buildpack.csproj
+++ b/src/Web.Config.Transform.Buildpack/Web.Config.Transform.Buildpack.csproj
@@ -18,6 +18,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
     <PackageReference Include="Microsoft.Web.Xdt" Version="3.0.0" />
-    <PackageReference Include="Steeltoe.Extensions.Configuration.ConfigServerCore" Version="2.2.0" />
+    <PackageReference Include="Steeltoe.Extensions.Configuration.ConfigServerCore" Version="2.4.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
…SCS 2.x versions